### PR TITLE
Show javac code as the diagnostics code if the problem is generated by Javac

### DIFF
--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseDiagnosticsHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/BaseDiagnosticsHandler.java
@@ -62,6 +62,10 @@ public abstract class BaseDiagnosticsHandler implements IProblemRequestor {
 	public static final int NON_PROJECT_JAVA_FILE = 0x10;
 	public static final int NOT_ON_CLASSPATH = 0x20;
 
+	public static final String DIAG_JAVAC_CODE = "javacCode";
+	public static final String DIAG_ECJ_PROBLEM_ID = "ecjProblemId";
+	public static final String DIAG_ARGUMENTS = "arguments";
+
 	public BaseDiagnosticsHandler(JavaClientConnection conn, ICompilationUnit cu) {
 		problems = new ArrayList<>();
 		this.cu = cu;
@@ -253,7 +257,7 @@ public abstract class BaseDiagnosticsHandler implements IProblemRequestor {
 			diag.setRange(convertRange(openable, problem));
 			Map<String, Object> data = new HashMap<>();
 			if (problem.getID() == IProblem.UndefinedName || problem.getID() == IProblem.UndefinedType || problem.getID() == IProblem.UninitializedBlankFinalField) {
-				data.put("arguments", problem.getArguments());
+				data.put(DIAG_ARGUMENTS, problem.getArguments());
 			}
 			if (isDiagnosticTagSupported) {
 				diag.setTags(getDiagnosticTag(problem.getID()));
@@ -264,9 +268,9 @@ public abstract class BaseDiagnosticsHandler implements IProblemRequestor {
 				if (extraAttributeNames != null && extraAttributeValues != null
 					&& extraAttributeNames.length == extraAttributeValues.length) {
 					for (int i = 0; i < extraAttributeNames.length; i++) {
-						if ("javacCode".equals(extraAttributeNames[i])) {
+						if (DIAG_JAVAC_CODE.equals(extraAttributeNames[i])) {
 							diag.setCode(String.valueOf(extraAttributeValues[i]));
-							data.put("ecjProblemId", Integer.toString(problem.getID()));
+							data.put(DIAG_ECJ_PROBLEM_ID, Integer.toString(problem.getID()));
 							break;
 						}
 					}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
@@ -347,7 +347,7 @@ public class CodeActionHandler {
 			List<String> arguments = new ArrayList<>();
 			if (diagnostic.getData() != null) {
 				Map<String, Object> data = JSONUtility.toModel(diagnostic.getData(), Map.class);
-				Object args = data.get("arguments");
+				Object args = data.get(BaseDiagnosticsHandler.DIAG_ARGUMENTS);
 				if (args instanceof JsonArray args1) {
 					for (JsonElement e : args1) {
 						arguments.add(e.getAsString());
@@ -355,7 +355,7 @@ public class CodeActionHandler {
 				} else if (args instanceof String[] args1) {
 					arguments = Arrays.asList(args1);
 				}
-				Object ecjProblemId = data.get("ecjProblemId");
+				Object ecjProblemId = data.get(BaseDiagnosticsHandler.DIAG_ECJ_PROBLEM_ID);
 				if (ecjProblemId instanceof String id) {
 					problemId = Integer.valueOf(id);
 				}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/CodeActionHandler.java
@@ -42,6 +42,7 @@ import org.eclipse.jdt.internal.ui.text.correction.proposals.NewMethodCorrection
 import org.eclipse.jdt.internal.ui.text.correction.proposals.NewVariableCorrectionProposalCore;
 import org.eclipse.jdt.ls.core.internal.ChangeUtil;
 import org.eclipse.jdt.ls.core.internal.JDTUtils;
+import org.eclipse.jdt.ls.core.internal.JSONUtility;
 import org.eclipse.jdt.ls.core.internal.JavaCodeActionKind;
 import org.eclipse.jdt.ls.core.internal.JavaLanguageServerPlugin;
 import org.eclipse.jdt.ls.core.internal.corrections.DiagnosticsHelper;
@@ -344,14 +345,19 @@ public class CodeActionHandler {
 			boolean isError = diagnostic.getSeverity() == DiagnosticSeverity.Error;
 			int problemId = getProblemId(diagnostic);
 			List<String> arguments = new ArrayList<>();
-			if (diagnostic.getData() instanceof JsonArray data) {
-				for (JsonElement e : data) {
-					arguments.add(e.getAsString());
+			if (diagnostic.getData() != null) {
+				Map<String, Object> data = JSONUtility.toModel(diagnostic.getData(), Map.class);
+				Object args = data.get("arguments");
+				if (args instanceof JsonArray args1) {
+					for (JsonElement e : args1) {
+						arguments.add(e.getAsString());
+					}
+				} else if (args instanceof String[] args1) {
+					arguments = Arrays.asList(args1);
 				}
-			}
-			if (diagnostic.getData() instanceof String[] data) {
-				for (String s : data) {
-					arguments.add(s);
+				Object ecjProblemId = data.get("ecjProblemId");
+				if (ecjProblemId instanceof String id) {
+					problemId = Integer.valueOf(id);
 				}
 			}
 			locations[i] = new ProblemLocation(start, end - start, problemId, arguments.toArray(new String[0]), isError, IJavaModelMarker.JAVA_MODEL_PROBLEM_MARKER);

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceDiagnosticsHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceDiagnosticsHandler.java
@@ -412,10 +412,10 @@ public final class WorkspaceDiagnosticsHandler implements IResourceChangeListene
 		}
 		d.setRange(range);
 		try {
-			if (marker.getAttribute("javacCode") != null) {
-				String javacCode = (String) marker.getAttribute("javacCode");
+			if (marker.getAttribute(BaseDiagnosticsHandler.DIAG_JAVAC_CODE) != null) {
+				String javacCode = (String) marker.getAttribute(BaseDiagnosticsHandler.DIAG_JAVAC_CODE);
 				Map<String, Object> data = new HashMap<>();
-				data.put("ecjProblemId", String.valueOf(problemId));
+				data.put(BaseDiagnosticsHandler.DIAG_ECJ_PROBLEM_ID, String.valueOf(problemId));
 				d.setCode(javacCode);
 				d.setData(data);
 			}
@@ -472,10 +472,10 @@ public final class WorkspaceDiagnosticsHandler implements IResourceChangeListene
 			d.setTags(DiagnosticsHandler.getDiagnosticTag(problemId));
 		}
 		try {
-			if (marker.getAttribute("javacCode") != null) {
-				String javacCode = (String) marker.getAttribute("javacCode");
+			if (marker.getAttribute(BaseDiagnosticsHandler.DIAG_JAVAC_CODE) != null) {
+				String javacCode = (String) marker.getAttribute(BaseDiagnosticsHandler.DIAG_JAVAC_CODE);
 				Map<String, Object> data = new HashMap<>();
-				data.put("ecjProblemId", String.valueOf(problemId));
+				data.put(BaseDiagnosticsHandler.DIAG_ECJ_PROBLEM_ID, String.valueOf(problemId));
 				d.setCode(javacCode);
 				d.setData(data);
 			}

--- a/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceDiagnosticsHandler.java
+++ b/org.eclipse.jdt.ls.core/src/org/eclipse/jdt/ls/core/internal/handlers/WorkspaceDiagnosticsHandler.java
@@ -16,6 +16,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -410,6 +411,17 @@ public final class WorkspaceDiagnosticsHandler implements IResourceChangeListene
 			d.setTags(DiagnosticsHandler.getDiagnosticTag(problemId));
 		}
 		d.setRange(range);
+		try {
+			if (marker.getAttribute("javacCode") != null) {
+				String javacCode = (String) marker.getAttribute("javacCode");
+				Map<String, Object> data = new HashMap<>();
+				data.put("ecjProblemId", String.valueOf(problemId));
+				d.setCode(javacCode);
+				d.setData(data);
+			}
+		} catch (CoreException e) {
+			// do nothing
+		}
 		return d;
 	}
 
@@ -458,6 +470,17 @@ public final class WorkspaceDiagnosticsHandler implements IResourceChangeListene
 		d.setRange(convertRange(document, marker));
 		if (isDiagnosticTagSupported) {
 			d.setTags(DiagnosticsHandler.getDiagnosticTag(problemId));
+		}
+		try {
+			if (marker.getAttribute("javacCode") != null) {
+				String javacCode = (String) marker.getAttribute("javacCode");
+				Map<String, Object> data = new HashMap<>();
+				data.put("ecjProblemId", String.valueOf(problemId));
+				d.setCode(javacCode);
+				d.setData(data);
+			}
+		} catch (CoreException e) {
+			// do nothing
 		}
 		return d;
 	}


### PR DESCRIPTION
Since the diagnostic message is Javac style, it's natural to keep the error code as consistent.

![image](https://github.com/user-attachments/assets/267c32c4-7aae-443b-ad9c-25bb91fca3b4)
